### PR TITLE
Source asdf.sh at new location

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -30,4 +30,8 @@ else
 fi
 unset asdf_data
 
-source ${ASDF_DIR}/lib/asdf.sh
+if [ -f "${ASDF_DIR}/lib/asdf.sh" ]; then
+  source ${ASDF_DIR}/lib/asdf.sh
+else
+  source ${ASDF_DIR}/asdf.sh
+fi


### PR DESCRIPTION
asdf [recently removed](https://github.com/asdf-vm/asdf/commit/00fee78423de0e399f5705bb483e599e39b707c9#diff-e7ff403bf8445295549da024e807556f3b106732721ba5e7136ef731d750fb5d) the file `/lib/asdf.sh` and moved the function to `/asdf.sh` instead.
