### PR TITLE
Support asdf v0.12.0

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -30,4 +30,9 @@ else
 fi
 unset asdf_data
 
-source ${ASDF_DIR}/lib/asdf.sh
+# `asdf shell` is moved to ${ASDF_DIR}/asdf.sh since asdf v0.12.0
+if [[ -f ${ASDF_DIR}/lib/asdf.sh ]]; then
+  source ${ASDF_DIR}/lib/asdf.sh
+else
+  source ${ASDF_DIR}/asdf.sh
+fi


### PR DESCRIPTION
I'm getting `no such file or directory: .asdf/lib/asdf.sh` error message from this plugin. Turns out since asdf v0.12.0, the `asdf shell` wrapper is no longer in `${ASDF_DIR}/lib/asdf.sh`, it was moved to `${ASDF_DIR}/asdf.sh`.

Ref: https://asdf-vm.com/guide/getting-started.html#_3-install-asdf